### PR TITLE
Fix AJC compiler not recognizable by Intellij IDEA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,35 +342,53 @@
       by Eclipse, leading to problems ever since the 'java8' profile was introduced here because it also
       defines a property.
     -->
-
-      <profile>
-          <id>tools-jar</id>
-          <activation>
-              <jdk>1.8</jdk> <!-- activate only on JDK8, as 8 is minimum version to run aspectj on-->
-          </activation>
-          <dependencies>
-              <dependency>
-                  <groupId>com.sun</groupId>
-                  <artifactId>tools</artifactId>
-                  <version>1.8</version>
-                  <scope>system</scope>
-                  <systemPath>${java.home}/../lib/tools.jar</systemPath>
-              </dependency>
-          </dependencies>
-      </profile>
-      <profile>
-          <id>java8</id>
-          <activation>
-              <jdk>[1.8,)</jdk>
-          </activation>
-          <properties>
-              <!--
-                Because of this properties section the old way of setting the tools.jar path via a property defined in
-                another profile does not work anymore when importing Maven projects into Eclipse. :-(
-              -->
-              <additionalparam>-Xdoclint:none</additionalparam>
-          </properties>
-      </profile>
+    <profile>
+      <id>standardToolsJar-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <file>
+          <exists>${java.home}/../lib/tools.jar</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>appleJdkToolsJar-profile</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <file>
+          <exists>${java.home}/../Classes/classes.jar</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <scope>system</scope>
+          <systemPath>${java.home}/../Classes/classes.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <!--
+          Because of this properties section the old way of setting the tools.jar path via a property defined in
+          another profile does not work anymore when importing Maven projects into Eclipse. :-(
+        -->
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
     <profile>
       <id>maven-repo-local</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -351,12 +351,6 @@
         </file>
       </activation>
       <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <scope>system</scope>
-          <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -368,12 +362,6 @@
         </file>
       </activation>
       <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <scope>system</scope>
-          <systemPath>${java.home}/../Classes/classes.jar</systemPath>
-        </dependency>
       </dependencies>
     </profile>
     <profile>


### PR DESCRIPTION
Added maven profile which is neccessary for IDEA to select AJC compiler and not fallback for Javac every time reimport is made.